### PR TITLE
Disable Self-Registration for fEMR Realm

### DIFF
--- a/dev/femr/config/keycloak/realm-data.json
+++ b/dev/femr/config/keycloak/realm-data.json
@@ -2250,7 +2250,7 @@
     "actionTokenGeneratedByUserLifespan": 300,
     "enabled": true,
     "sslRequired": "external",
-    "registrationAllowed": true,
+    "registrationAllowed": false,
     "registrationEmailAsUsername": true,
     "rememberMe": true,
     "verifyEmail": false,


### PR DESCRIPTION
In the UI, other settings appear to be disabled when this change is made. But, I diff'd realm exports before and after the UI change, and this was the only difference.