### PR TITLE
Patientsearch Hotreloading

### DIFF
--- a/dev/freestanding/femr/default.env
+++ b/dev/freestanding/femr/default.env
@@ -14,7 +14,8 @@
 # PDMP_IMAGE_TAG=tag-from-topic-branch
 
 # docker-compose development overrides; uncomment to enable
-# COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.pdmp.yaml
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.pdmp.yaml:docker-compose.dev.dashboard.yaml
 
 # uncomment & modify if using above development overrides
 # PDMP_CHECKOUT_DIR=
+# DASHBOARD_CHECKOUT_DIR=

--- a/dev/freestanding/femr/docker-compose.dev.dashboard.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.dashboard.yaml
@@ -1,0 +1,14 @@
+# docker-compose development override for dashboard service
+---
+version: "3.7"
+services:
+  dashboard:
+    command: sh -c "cd /opt/app && flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    environment:
+      FLASK_ENV: development
+      FLASK_APP: patientsearch:create_app()
+      # use static frontend built in docker image
+      STATIC_DIR: /opt/cosri-patientsearch/patientsearch/static/
+    volumes:
+    # set in .env
+      - "${DASHBOARD_CHECKOUT_DIR}/:/opt/app"


### PR DESCRIPTION
* Configure checkout path and patientsearch will hotreload
* NB: frontend does not rebuild; uses version built into docker image
* Requires [Make flask static directory configurable](https://github.com/uwcirg/cosri-patientsearch/pull/21)