### PR TITLE
Re-title fEMR login to "Cosri"

### DIFF
--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -2231,6 +2231,7 @@
   {
     "id": "femr",
     "realm": "fEMR",
+    "displayName": "Cosri",
     "notBefore": 0,
     "revokeRefreshToken": false,
     "refreshTokenMaxReuse": 0,

--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -2231,7 +2231,7 @@
   {
     "id": "femr",
     "realm": "fEMR",
-    "displayName": "Cosri",
+    "displayName": "COSRI (Clinical Opioid Summary with Rx Integration)",
     "notBefore": 0,
     "revokeRefreshToken": false,
     "refreshTokenMaxReuse": 0,


### PR DESCRIPTION
Add display override for fEMR Keycloak realm, for "COSRI (Clinical Opioid Summary with Rx Integration)"

![image](https://user-images.githubusercontent.com/5333433/123701892-49dd0100-d817-11eb-9225-bea9305857f3.png)
