### PR TITLE
Add DEA attribute to KeyCloak

### DIFF
--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -963,21 +963,6 @@
             }
           },
           {
-            "id": "c5237a00-d3ea-4e87-9caf-5146b02d1a15",
-            "name": "DEA",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-property-mapper",
-            "consentRequired": false,
-            "config": {
-              "userinfo.token.claim": "true",
-              "user.attribute": "DEA",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "DEA",
-              "jsonType.label": "String"
-            }
-          },
-          {
             "id": "f5a5f6b3-1872-426f-b23c-75ddbe2e8e55",
             "name": "groups",
             "protocol": "openid-connect",
@@ -2983,6 +2968,21 @@
         "authenticationFlowBindingOverrides": {},
         "fullScopeAllowed": true,
         "nodeReRegistrationTimeout": -1,
+        "protocolMappers" : [ {
+          "id" : "de38c2d5-0c80-4943-a370-eb5f95c4b67c",
+          "name" : "DEA",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "DEA",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "DEA",
+            "jsonType.label" : "String"
+          }
+        } ],
         "defaultClientScopes": [
           "web-origins",
           "role_list",

--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -963,6 +963,21 @@
             }
           },
           {
+            "id": "c5237a00-d3ea-4e87-9caf-5146b02d1a15",
+            "name": "DEA",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": false,
+            "config": {
+              "userinfo.token.claim": "true",
+              "user.attribute": "DEA",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "DEA",
+              "jsonType.label": "String"
+            }
+          },
+          {
             "id": "f5a5f6b3-1872-426f-b23c-75ddbe2e8e55",
             "name": "groups",
             "protocol": "openid-connect",
@@ -2612,6 +2627,7 @@
     "users": [
       {
         "id": "794d2782-e783-4cbb-ae72-b165a4c06e7f",
+        "attributes": {"DEA": "testDEAvalue"},
         "createdTimestamp": 1584919351977,
         "username": "test",
         "enabled": true,


### PR DESCRIPTION
Attempt to add the DEA attribute to KeyCloak as per https://www.baeldung.com/keycloak-custom-user-attributes instructions.

NB, found it necessary to follow the `Create Protocol Mapper` portion
TTW to see the DEA attribute in the JWT claims.