### PR TITLE
Tune Keycloak Timeouts

### DIFF
--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -2238,7 +2238,7 @@
     "accessTokenLifespan": 300,
     "accessTokenLifespanForImplicitFlow": 900,
     "ssoSessionIdleTimeout": 1800,
-    "ssoSessionMaxLifespan": 36000,
+    "ssoSessionMaxLifespan": 28800,
     "ssoSessionIdleTimeoutRememberMe": 0,
     "ssoSessionMaxLifespanRememberMe": 0,
     "offlineSessionIdleTimeout": 2592000,

--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -2235,7 +2235,7 @@
     "notBefore": 0,
     "revokeRefreshToken": false,
     "refreshTokenMaxReuse": 0,
-    "accessTokenLifespan": 7200,
+    "accessTokenLifespan": 300,
     "accessTokenLifespanForImplicitFlow": 900,
     "ssoSessionIdleTimeout": 1800,
     "ssoSessionMaxLifespan": 36000,

--- a/dev/freestanding/femr/config/keycloak/realm-data.json
+++ b/dev/freestanding/femr/config/keycloak/realm-data.json
@@ -2235,7 +2235,7 @@
     "notBefore": 0,
     "revokeRefreshToken": false,
     "refreshTokenMaxReuse": 0,
-    "accessTokenLifespan": 300,
+    "accessTokenLifespan": 1800,
     "accessTokenLifespanForImplicitFlow": 900,
     "ssoSessionIdleTimeout": 1800,
     "ssoSessionMaxLifespan": 28800,


### PR DESCRIPTION
- Reduce Access Token lifetime (to ~~5~~ 30 minutes)
- Reduce Keycloak session lifetime (to 8 hours)