### PR TITLE
Reverse proxy for validating Keycloak JWTs

### DIFF
--- a/dev/freestanding/femr/default.env
+++ b/dev/freestanding/femr/default.env
@@ -28,3 +28,4 @@
 # uncomment & modify if using above development overrides
 # PDMP_CHECKOUT_DIR=
 # DASHBOARD_CHECKOUT_DIR=
+# FHIRWALL_CHECKOUT_DIR=

--- a/dev/freestanding/femr/default.env
+++ b/dev/freestanding/femr/default.env
@@ -20,6 +20,7 @@
 # FHIR_IMAGE_TAG=tag-from-topic-branch
 # HYDRANT_IMAGE_TAG=tag-from-topic-branch
 # PDMP_IMAGE_TAG=tag-from-topic-branch
+# PROXY_IMAGE_TAG=tag-from-topic-branch
 
 # docker-compose development overrides; uncomment to enable
 # COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.pdmp.yaml:docker-compose.dev.dashboard.yaml

--- a/dev/freestanding/femr/docker-compose.dev.fhirwall.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.fhirwall.yaml
@@ -1,0 +1,7 @@
+# docker-compose development override for fhirwall service
+version: "3.7"
+services:
+  fhirwall:
+    volumes:
+    # set in .env
+      - '${FHIRWALL_CHECKOUT_DIR}/:/opt/app'

--- a/dev/freestanding/femr/docker-compose.yaml
+++ b/dev/freestanding/femr/docker-compose.yaml
@@ -17,9 +17,9 @@ services:
         }}'
       EXTERNAL_FHIR_API: 'http://pdmp:8008/v/r2/fhir/'
       # FHIR URL queried by PDMP integration backend
-      MAP_API: 'https://fhir.${BASE_DOMAIN:-localtest.me}/hapi-fhir-jpaserver/fhir/'
+      MAP_API: "http://fhir:8080/hapi-fhir-jpaserver/fhir/"
       # FHIR URL passed to SoF client
-      SOF_HOST_FHIR_URL: 'https://fhir.${BASE_DOMAIN:-localtest.me}/hapi-fhir-jpaserver/fhir/'
+      SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/hapi-fhir-jpaserver/fhir'
       SOF_CLIENT_LAUNCH_URL: 'https://backend.${BASE_DOMAIN:-localtest.me}/auth/launch'
       LOGSERVER_URL: "https://logs.${LOGS_BASE_DOMAIN:-localtest.me}"
       LOGSERVER_TOKEN: ${LOGSERVER_TOKEN}

--- a/dev/freestanding/femr/docker-compose.yaml
+++ b/dev/freestanding/femr/docker-compose.yaml
@@ -96,6 +96,22 @@ services:
       - internal
 
 
+  fhirwall:
+    image: ghcr.io/uwcirg/jwt-proxy:${PROXY_IMAGE_TAG:-develop}
+    environment:
+      UPSTREAM_SERVER: "http://fhir:8080"
+      JWKS_URL: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/certs"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.rule=Host(`fhirwall.${BASE_DOMAIN:-localtest.me}`)"
+      - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.tls=true"
+      - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
+    networks:
+      - ingress
+      - internal
+
+
   pdmp:
     image: uwcirg/script-fhir-facade:${PDMP_IMAGE_TAG:-latest}
     environment:


### PR DESCRIPTION
- Protect HAPI with reverse proxy for validating JWTs
