### PR TITLE
Add internal-network service aliases

### DIFF
--- a/dev/freestanding/cosri/docker-compose.yaml
+++ b/dev/freestanding/cosri/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       # ultimate destination after SoF launch and backend auth
       LAUNCH_DEST: 'https://frontend.${BASE_DOMAIN:-localtest.me}/launch.html'
 
-      PDMP_URL: 'http://pdmp:8008'
+      PDMP_URL: 'http://pdmp-internal:8008'
 
       # do not pass launch/patient or Epic will infer standalone launch
       SOF_CLIENT_SCOPES: "patient/*.read launch openid profile"
@@ -70,7 +70,10 @@ services:
     volumes:
       - ./config/pdmp:/opt/app/config:ro
     networks:
-      - internal
+      ingress:
+      internal:
+        aliases:
+          - pdmp-internal
     depends_on:
       - redis
 

--- a/dev/freestanding/femr/docker-compose.yaml
+++ b/dev/freestanding/femr/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
         }}'
       EXTERNAL_FHIR_API: 'http://pdmp:8008/v/r2/fhir/'
       # FHIR URL queried by PDMP integration backend
-      MAP_API: "http://fhir:8080/hapi-fhir-jpaserver/fhir/"
+      MAP_API: "http://fhir-internal:8080/hapi-fhir-jpaserver/fhir/"
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/hapi-fhir-jpaserver/fhir'
       SOF_CLIENT_LAUNCH_URL: 'https://backend.${BASE_DOMAIN:-localtest.me}/auth/launch'
@@ -103,14 +103,16 @@ services:
       - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
     networks:
-      - ingress
-      - internal
+      ingress:
+      internal:
+        aliases:
+          - fhir-internal
 
 
   fhirwall:
     image: ghcr.io/uwcirg/jwt-proxy:${PROXY_IMAGE_TAG:-latest}
     environment:
-      UPSTREAM_SERVER: "http://fhir:8080"
+      UPSTREAM_SERVER: "http://fhir-internal:8080"
       JWKS_URL: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/certs"
     labels:
       - "traefik.enable=true"
@@ -149,7 +151,7 @@ services:
     environment:
       SECRET_KEY: ${HYDRANT_SECRET_KEY:-qiLYeYMJf8i7y0xU}
       PREFERRED_URL_SCHEME: https
-      FHIR_SERVER_URL: "fhir:8080/hapi-fhir-jpaserver/fhir"
+      FHIR_SERVER_URL: "fhir-internal:8080/hapi-fhir-jpaserver/fhir"
 
 
   redis:

--- a/dev/freestanding/femr/docker-compose.yaml
+++ b/dev/freestanding/femr/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
           "token_uri": "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token",
           "token_introspection_uri": "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
         }}'
-      EXTERNAL_FHIR_API: 'http://pdmp:8008/v/r2/fhir/'
+      EXTERNAL_FHIR_API: 'http://pdmp-internal:8008/v/r2/fhir/'
       # FHIR URL queried by PDMP integration backend
       MAP_API: "http://fhir-internal:8080/hapi-fhir-jpaserver/fhir/"
       # FHIR URL passed to SoF client
@@ -140,8 +140,10 @@ services:
       - "traefik.http.routers.pdmp-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.pdmp-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
     networks:
-      - ingress
-      - internal
+      ingress:
+      internal:
+        aliases:
+          - pdmp-internal
     depends_on:
       - redis
 


### PR DESCRIPTION
- Add aliases on internal network, for services connected to both ingress and internal networks
- Use internal network alias to ensure traffic does not use ingress network
