### PR TITLE
Add system type config to Keycloak realm title

### DIFF
--- a/base/freestanding/femr/config/keycloak/realm-data.json
+++ b/base/freestanding/femr/config/keycloak/realm-data.json
@@ -2231,7 +2231,7 @@
   {
     "id": "femr",
     "realm": "fEMR",
-    "displayName": "COSRI (Clinical Opioid Summary with Rx Integration)",
+    "displayName": "COSRI (Clinical Opioid Summary with Rx Integration) ${__KEYCLOAK_SYSTEM_TYPE}",
     "notBefore": 0,
     "revokeRefreshToken": false,
     "refreshTokenMaxReuse": 0,

--- a/dev/freestanding/femr/keycloak.env.default
+++ b/dev/freestanding/femr/keycloak.env.default
@@ -5,6 +5,8 @@
 # Variables defined in this file will only be available to containers/images
 # ie not for interpolation in docker-compose YAML files
 
+__KEYCLOAK_SYSTEM_TYPE=development
+
 __KEYCLOAK_EMAIL_USER=keycloak-femr@cirg.washington.edu
 __KEYCLOAK_EMAIL_PASSWORD=
 


### PR DESCRIPTION
- Add system type to realm title (and login page)
  - Defaults to `development`
![image](https://user-images.githubusercontent.com/5333433/132447932-817fb1b7-7988-422f-881b-8bef8fd74d18.png)
