### PR TITLE
Integrate Keycloak Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "base/freestanding/logs/logserver"]
 	path = base/freestanding/logs/logserver
 	url = https://github.com/uwcirg/logserver
+[submodule "base/freestanding/femr/config/keycloak/cosri-keycloak-theme"]
+	path = base/freestanding/femr/config/keycloak/cosri-keycloak-theme
+	url = https://github.com/uwcirg/cosri-keycloak-theme

--- a/base/freestanding/femr/config/keycloak/realm-data.json
+++ b/base/freestanding/femr/config/keycloak/realm-data.json
@@ -2954,7 +2954,7 @@
           "saml.force.post.binding": "false",
           "saml.multivalued.roles": "false",
           "saml.encrypt": "false",
-          "login_theme": "keycloak",
+          "login_theme": "cosri",
           "saml.server.signature": "false",
           "saml.server.signature.keyinfo.ext": "false",
           "exclude.session.state.from.auth.response": "false",

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
     volumes:
       - "./config/keycloak/docker-entrypoint-override.sh:/opt/jboss/tools/docker-entrypoint-override.sh:ro"
       - "./config/keycloak/realm-data.json:/tmp/realm-data.json"
+      - "./config/keycloak/cosri-keycloak-theme:/opt/jboss/keycloak/themes/cosri"
     depends_on:
       - db
     networks:


### PR DESCRIPTION
- Add [Keycloak theme](https://github.com/uwcirg/cosri-keycloak-theme) as git submodule
- Use as default login theme for fEMR login