### PR TITLE
Fixup Login Themes

### DIFF
--- a/base/freestanding/femr/config/keycloak/realm-data.json
+++ b/base/freestanding/femr/config/keycloak/realm-data.json
@@ -2954,7 +2954,6 @@
           "saml.force.post.binding": "false",
           "saml.multivalued.roles": "false",
           "saml.encrypt": "false",
-          "login_theme": "cosri",
           "saml.server.signature": "false",
           "saml.server.signature.keyinfo.ext": "false",
           "exclude.session.state.from.auth.response": "false",

--- a/base/freestanding/femr/config/keycloak/realm-data.json
+++ b/base/freestanding/femr/config/keycloak/realm-data.json
@@ -3099,7 +3099,6 @@
           "saml.force.post.binding": "false",
           "saml.multivalued.roles": "false",
           "saml.encrypt": "false",
-          "login_theme": "base",
           "saml.server.signature": "false",
           "saml.server.signature.keyinfo.ext": "false",
           "exclude.session.state.from.auth.response": "false",


### PR DESCRIPTION
- Remove theme config from individual OIDC clients
- Inherit `cosri` theme [from realm settings (`loginTheme`)](https://github.com/uwcirg/cosri-environments/blob/0b68cb74fd4ecc41c622435779a6c4c25cb6fbd2/base/freestanding/femr/config/keycloak/realm-data.json#L3656)
