### PR TITLE
Feature/kc logging config

### DIFF
--- a/base/freestanding/femr/config/keycloak/disable-theme-cache.cli
+++ b/base/freestanding/femr/config/keycloak/disable-theme-cache.cli
@@ -1,0 +1,5 @@
+embed-server --std-out=echo --server-config=standalone-ha.xml
+/subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheThemes,value=false)
+/subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheTemplates,value=false)
+/subsystem=keycloak-server/theme=defaults/:write-attribute(name=staticMaxAge,value=-1)
+stop-embedded-server

--- a/base/freestanding/femr/config/keycloak/jboss-logging-config.cli
+++ b/base/freestanding/femr/config/keycloak/jboss-logging-config.cli
@@ -1,0 +1,11 @@
+embed-server --std-out=echo --server-config=standalone-ha.xml
+
+# Change to JSON formatting
+/subsystem=logging/json-formatter=JSON:add(exception-output-type=formatted)
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter,value=JSON)
+
+# To pick up LOGIN and other events, tune keycloak.events to level DEBUG
+/subsystem=logging/logger=org.keycloak.events:add
+/subsystem=logging/logger=org.keycloak.events:write-attribute(name=level,value=DEBUG)
+
+stop-embedded-server

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -71,7 +71,6 @@ services:
       - "./config/keycloak/docker-entrypoint-override.sh:/opt/jboss/tools/docker-entrypoint-override.sh:ro"
       - "./config/keycloak/realm-data.json:/tmp/realm-data.json"
       - "./config/keycloak/cosri-keycloak-theme:/opt/jboss/keycloak/themes/cosri"
-      - "./config/keycloak/disable-theme-cache.cli:/opt/jboss/startup-scripts/disable-theme-cache.cli"
       - "./config/keycloak/jboss-logging-config.cli:/opt/jboss/startup-scripts/jboss-logging-config.cli"
     depends_on:
       - db

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -71,6 +71,8 @@ services:
       - "./config/keycloak/docker-entrypoint-override.sh:/opt/jboss/tools/docker-entrypoint-override.sh:ro"
       - "./config/keycloak/realm-data.json:/tmp/realm-data.json"
       - "./config/keycloak/cosri-keycloak-theme:/opt/jboss/keycloak/themes/cosri"
+      - "./config/keycloak/disable-theme-cache.cli:/opt/jboss/startup-scripts/disable-theme-cache.cli"
+      - "./config/keycloak/jboss-logging-config.cli:/opt/jboss/startup-scripts/jboss-logging-config.cli"
     depends_on:
       - db
     networks:

--- a/dev/freestanding/femr/config/keycloak/disable-theme-cache.cli
+++ b/dev/freestanding/femr/config/keycloak/disable-theme-cache.cli
@@ -1,3 +1,6 @@
+# disable Keycloak theme caching
+# configure Keycloak to re-render themes on every request
+
 embed-server --std-out=echo --server-config=standalone-ha.xml
 /subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheThemes,value=false)
 /subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheTemplates,value=false)

--- a/dev/freestanding/femr/default.env
+++ b/dev/freestanding/femr/default.env
@@ -19,7 +19,7 @@
 COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compose.yaml
 
 # docker-compose development overrides; uncomment to enable
-# COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compose.yaml:docker-compose.dev.pdmp.yaml:docker-compose.dev.dashboard.yaml:docker-compose.dev.hydrant.yaml
+# COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compose.yaml:docker-compose.dev.pdmp.yaml:docker-compose.dev.dashboard.yaml:docker-compose.dev.hydrant.yaml:docker-compose.dev.keycloak.yaml
 
 # uncomment & modify if using above development overrides
 # PDMP_CHECKOUT_DIR=

--- a/dev/freestanding/femr/docker-compose.dev.keycloak.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.keycloak.yaml
@@ -1,0 +1,6 @@
+# docker-compose override to disable theme caching
+version: "3.7"
+services:
+  keycloak:
+    volumes:
+      - "../../../dev/freestanding/femr/config/keycloak/disable-theme-cache.cli:/opt/jboss/startup-scripts/disable-theme-cache.cli"


### PR DESCRIPTION
Add to KC volume list, the cli scripts to configure keycloak on bootstrap.  (NB, at least the `disable-theme-cache.cli` should probably move to `/dev`)

Added keycloak-cli scripts to:
- configure logging so LOGIN and related events are in JSON format on stdout
- disabled theme caching (probably only desired when actively being worked on)