### PR TITLE
Flask dev overrides

### DIFF
--- a/dev/freestanding/cosri/docker-compose.dev.backend.yaml
+++ b/dev/freestanding/cosri/docker-compose.dev.backend.yaml
@@ -2,6 +2,9 @@
 version: "3.7"
 services:
   backend:
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    environment:
+      FLASK_ENV: development
     volumes:
     # set in .env
       - '${BACKEND_CHECKOUT_DIR}/:/opt/app'

--- a/dev/freestanding/cosri/docker-compose.dev.pdmp.yaml
+++ b/dev/freestanding/cosri/docker-compose.dev.pdmp.yaml
@@ -2,6 +2,9 @@
 version: "3.7"
 services:
   pdmp:
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8008}"
+    environment:
+      FLASK_ENV: development
     volumes:
     # set in .env
       - '${PDMP_CHECKOUT_DIR}/:/opt/app'

--- a/dev/freestanding/femr/docker-compose.dev.dashboard.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.dashboard.yaml
@@ -6,7 +6,6 @@ services:
     command: sh -c "cd /opt/app && flask run --host 0.0.0.0 --port ${PORT:-8000}"
     environment:
       FLASK_ENV: development
-      FLASK_APP: patientsearch:create_app()
       # use static frontend built in docker image
       STATIC_DIR: /opt/cosri-patientsearch/patientsearch/static/
     volumes:

--- a/dev/freestanding/femr/docker-compose.dev.fhirwall.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.fhirwall.yaml
@@ -2,6 +2,9 @@
 version: "3.7"
 services:
   fhirwall:
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    environment:
+      FLASK_ENV: development
     volumes:
     # set in .env
       - '${FHIRWALL_CHECKOUT_DIR}/:/opt/app'

--- a/dev/freestanding/femr/docker-compose.dev.fhirwall.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.fhirwall.yaml
@@ -2,7 +2,7 @@
 version: "3.7"
 services:
   fhirwall:
-    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8008}"
     environment:
       FLASK_ENV: development
     volumes:

--- a/dev/freestanding/femr/docker-compose.dev.pdmp.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.pdmp.yaml
@@ -2,7 +2,7 @@
 version: "3.7"
 services:
   pdmp:
-    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8008}"
     environment:
       FLASK_ENV: development
     volumes:

--- a/dev/freestanding/femr/docker-compose.dev.pdmp.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.pdmp.yaml
@@ -2,6 +2,9 @@
 version: "3.7"
 services:
   pdmp:
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    environment:
+      FLASK_ENV: development
     volumes:
     # set in .env
       - '${PDMP_CHECKOUT_DIR}/:/opt/app'


### PR DESCRIPTION
- Use flask development webserver in docker-compose dev overrides
  - Default webserver is now gunicorn
