### PR TITLE
Fixup Keycloak registrationEmailAsUsername

### DIFF
--- a/base/freestanding/femr/config/keycloak/realm-data.json
+++ b/base/freestanding/femr/config/keycloak/realm-data.json
@@ -2253,7 +2253,7 @@
     "enabled": true,
     "sslRequired": "external",
     "registrationAllowed": false,
-    "registrationEmailAsUsername": true,
+    "registrationEmailAsUsername": false,
     "rememberMe": true,
     "verifyEmail": false,
     "loginWithEmailAllowed": true,


### PR DESCRIPTION
- Do not use email as username for registration (may fix [PT#179983899](https://www.pivotaltracker.com/story/show/179983899))
- Update Keycloak theme to latest version
