### PR TITLE
Disable referential integrity

### DIFF
--- a/base/freestanding/femr/config/fhir/application.yaml
+++ b/base/freestanding/femr/config/fhir/application.yaml
@@ -65,7 +65,7 @@ hapi:
 #    enable_repository_validating_interceptor: false
 #    enable_index_missing_fields: false
 #    enable_index_contained_resource: false
-#    enforce_referential_integrity_on_delete: false
+    enforce_referential_integrity_on_delete: false
 #    enforce_referential_integrity_on_write: false
 #    etag_support_enabled: true
 #    expunge_enabled: true


### PR DESCRIPTION
Disable referential integrity between FHIR resources to match behavior in Hapi 4.2.0