### PR TITLE
Require auth for gwen

### DIFF
--- a/base/freestanding/logs/docker-compose.ingress.yaml
+++ b/base/freestanding/logs/docker-compose.ingress.yaml
@@ -11,12 +11,14 @@ services:
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
 
+      # traefik forwardauth: require that requests are validated (return 200) by oidc-proxy before forwarding to service
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.middlewares=gwen-${COMPOSE_PROJECT_NAME}-forwardauth"
       - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"
       - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.authResponseHeaders=X-Forwarded-User"
     networks:
       - ingress
       - internal
+
   postgrest:
     labels:
       - "traefik.enable=true"
@@ -25,7 +27,7 @@ services:
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
 
-
+      # traefik forwardauth: require that requests are validated (return 200) by oidc-proxy before forwarding to service
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.middlewares=logserver-${COMPOSE_PROJECT_NAME}-forwardauth"
       - "traefik.http.middlewares.logserver-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"
       - "traefik.http.middlewares.logserver-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.authResponseHeaders=X-Forwarded-User"

--- a/base/freestanding/logs/docker-compose.ingress.yaml
+++ b/base/freestanding/logs/docker-compose.ingress.yaml
@@ -10,6 +10,10 @@ services:
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
+
+      - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.middlewares=gwen-${COMPOSE_PROJECT_NAME}-forwardauth"
+      - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"
+      - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.authResponseHeaders=X-Forwarded-User"
     networks:
       - ingress
       - internal

--- a/base/freestanding/logs/docker-compose.ingress.yaml
+++ b/base/freestanding/logs/docker-compose.ingress.yaml
@@ -12,6 +12,7 @@ services:
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
 
       # traefik forwardauth: require that requests are validated (return 200) by oidc-proxy before forwarding to service
+      # https://doc.traefik.io/traefik/middlewares/http/forwardauth/
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.middlewares=gwen-${COMPOSE_PROJECT_NAME}-forwardauth"
       - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"
       - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.authResponseHeaders=X-Forwarded-User"
@@ -28,6 +29,7 @@ services:
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
 
       # traefik forwardauth: require that requests are validated (return 200) by oidc-proxy before forwarding to service
+      # https://doc.traefik.io/traefik/middlewares/http/forwardauth/
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.middlewares=logserver-${COMPOSE_PROJECT_NAME}-forwardauth"
       - "traefik.http.middlewares.logserver-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"
       - "traefik.http.middlewares.logserver-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.authResponseHeaders=X-Forwarded-User"

--- a/base/freestanding/logs/docker-compose.ingress.yaml
+++ b/base/freestanding/logs/docker-compose.ingress.yaml
@@ -11,7 +11,7 @@ services:
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
 
-      # traefik forwardauth: require that requests are validated (return 200) by oidc-proxy before forwarding to service
+      # traefik forwardauth: require that requests are validated (return 200 OK) by oidc-proxy before forwarding to service
       # https://doc.traefik.io/traefik/middlewares/http/forwardauth/
       - "traefik.http.routers.gwen-${COMPOSE_PROJECT_NAME}.middlewares=gwen-${COMPOSE_PROJECT_NAME}-forwardauth"
       - "traefik.http.middlewares.gwen-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"
@@ -28,7 +28,7 @@ services:
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.tls=true"
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
 
-      # traefik forwardauth: require that requests are validated (return 200) by oidc-proxy before forwarding to service
+      # traefik forwardauth: require that requests are validated (return 200 OK) by oidc-proxy before forwarding to service
       # https://doc.traefik.io/traefik/middlewares/http/forwardauth/
       - "traefik.http.routers.logserver-${COMPOSE_PROJECT_NAME}.middlewares=logserver-${COMPOSE_PROJECT_NAME}-forwardauth"
       - "traefik.http.middlewares.logserver-${COMPOSE_PROJECT_NAME}-forwardauth.forwardauth.address=http://oidc-proxy-${COMPOSE_PROJECT_NAME}:4181"


### PR DESCRIPTION
Require Keycloak authorization using `logserver_openid_client` before allowing access to `gwen` service