### PR TITLE
Duplicate KeyCloak DB variables in hydrant environment for access

### DIFF
--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -146,6 +146,14 @@ services:
       PREFERRED_URL_SCHEME: https
       FHIR_SERVER_URL: "http://fhir-internal:8080/fhir"
       LOGSERVER_URL: "https://logs.${BASE_DOMAIN:-localtest.me}"
+      DB_VENDOR: postgres
+      DB_ADDR: db
+      DB_PORT: 5432
+      DB_DATABASE: keycloak
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+    depends_on:
+      - db
     networks:
       - internal
 

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -146,6 +146,8 @@ services:
       PREFERRED_URL_SCHEME: https
       FHIR_SERVER_URL: "http://fhir-internal:8080/fhir"
       LOGSERVER_URL: "https://logs.${BASE_DOMAIN:-localtest.me}"
+
+      # Keycloak database config
       DB_VENDOR: postgres
       DB_ADDR: db
       DB_PORT: 5432


### PR DESCRIPTION
Expose Keycloak database settings for hydrant to use in generating event log dumps.  See https://github.com/uwcirg/hydrant/pull/21
