### PR TITLE
Delete duplicate `fhirwall` section.

### DIFF
--- a/dev/freestanding/femr/docker-compose.yaml
+++ b/dev/freestanding/femr/docker-compose.yaml
@@ -10,11 +10,6 @@ services:
       - ../../../dev/freestanding/femr/keycloak.env
 
 
-  fhirwall:
-    env_file:
-      - ../../../dev/freestanding/femr/fhirwall.env
-
-
   # expose HAPI to internet
   fhir:
     labels:


### PR DESCRIPTION
Found a duplicate `fhirwall` section - removed.  Apparently, `docker-compose` doesn't mind...