### PR TITLE
Include patient banner in SoF launch when freestanding.

### DIFF
--- a/base/freestanding/cosri/docker-compose.yaml
+++ b/base/freestanding/cosri/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       # ultimate destination after SoF launch and backend auth
       LAUNCH_DEST: 'https://frontend.${BASE_DOMAIN:-localtest.me}/launch.html'
 
+      NEED_PATIENT_BANNER: "true"
       PDMP_URL: 'http://pdmp-internal:8008'
 
       # do not pass launch/patient or Epic will infer standalone launch


### PR DESCRIPTION
Necessary change in light of https://github.com/uwcirg/cosri-patientsearch/pull/180 , to continue to see the patient banner in freestanding mode.