### PR TITLE
Upgrade Hapi to 6.8.3

### DIFF
--- a/base/freestanding/femr/config/fhir/application.yaml
+++ b/base/freestanding/femr/config/fhir/application.yaml
@@ -1,5 +1,4 @@
-# https://raw.githubusercontent.com/hapifhir/hapi-fhir-jpaserver-starter/v6.2.2/src/main/resources/application.yaml
-
+# https://github.com/hapifhir/hapi-fhir-jpaserver-starter/blob/image/v6.8.3/src/main/resources/application.yaml
 #Adds the option to go to eg. http://localhost:8080/actuator/health for seeing the running configuration
 #see https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
 management:
@@ -30,10 +29,10 @@ spring:
     properties:
       hibernate.format_sql: false
       hibernate.show_sql: false
+
       #Hibernate dialect is automatically detected except Postgres and H2.
       #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
       #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
-
       hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
   #      hibernate.hbm2ddl.auto: update
   #      hibernate.jdbc.batch_size: 20
@@ -41,6 +40,7 @@ spring:
   #      hibernate.cache.use_second_level_cache: false
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
+
   ###    These settings will enable fulltext search with lucene or elastic
       hibernate.search.enabled: true
   ### lucene parameters
@@ -54,28 +54,39 @@ spring:
 #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
 hapi:
   fhir:
+
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
     fhir_version: R4
+    ### This flag when enabled to true, will avail evaluate measure operations from CR Module.
+    ### Flag is false by default, can be passed as command line argument to override.
+    cr_enabled: "${CR_ENABLED: false}"
     ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
     ### to determine the FHIR server address
     #   use_apache_address_strategy: false
     ### forces the use of the https:// protocol for the returned server address.
     ### alternatively, it may be set using the X-Forwarded-Proto header.
     #   use_apache_address_strategy_https: false
+    ### enables the server to host content like HTML, css, etc. under the url pattern of eg. /static/**
+    # staticLocationPrefix: /static
+    ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
+    #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
-    #    implementationguides:
+    ### tells the server whether to attempt to load IG resources that are already present
+    #    reload_existing_implementationGuides : false
+    #implementationguides:
     ###    example from registry (packages.fhir.org)
-    #      swiss:
-    #        name: swiss.mednet.fhir
-    #        version: 0.8.0
+    #  swiss:
+    #    name: swiss.mednet.fhir
+    #    version: 0.8.0
+    #    reloadExisting : false
     #      example not from registry
     #      ips_1_0_0:
-    #        url: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
+    #        packageUrl: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
     #        name: hl7.fhir.uv.ips
     #        version: 1.0.0
     #    supported_resource_types:
@@ -91,7 +102,10 @@ hapi:
     #    allow_multiple_delete: true
     #    allow_override_default_search_params: true
     #    auto_create_placeholder_reference_targets: false
-    #    cql_enabled: true
+    ### tells the server to automatically append the current version of the target resource to references at these paths
+    #    auto_version_reference_at_paths: Device.patient, Device.location, Device.parent, DeviceMetric.parent, DeviceMetric.source, Observation.device, Observation.subject
+    #    cr_enabled: true
+    #    ips_enabled: false
     #    default_encoding: JSON
     #    default_pretty_print: true
     #    default_page_size: 20
@@ -103,8 +117,8 @@ hapi:
     ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
     ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
     advanced_lucene_indexing: false
-    bulk_export_enabled: true
-    bulk_import_enabled: true
+    bulk_export_enabled: false
+    bulk_import_enabled: false
     #    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
     #    enforce_referential_integrity_on_delete: false
@@ -115,7 +129,7 @@ hapi:
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true
     #    graphql_enabled: true
-    #    narrative_enabled: true
+    narrative_enabled: false
     #    mdm_enabled: true
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
@@ -133,6 +147,14 @@ hapi:
     search-coord-core-pool-size: 20
     search-coord-max-pool-size: 100
     search-coord-queue-capacity: 200
+    
+    # comma-separated package names, will be @ComponentScan'ed by Spring to allow for creating custom Spring beans
+    #custom-bean-packages:
+    
+    # comma-separated list of fully qualified interceptor classes. 
+    # classes listed here will be fetched from the Spring context when combined with 'custom-bean-packages', 
+    # or will be instantiated via reflection using an no-arg contructor; then registered with the server  
+    #custom-interceptor-classes:  
 
     # Threadpool size for BATCH'ed GETs in a bundle.
     #    bundle_batch_pool_size: 10
@@ -183,7 +205,7 @@ hapi:
 #        quitWait:
 #    lastn_enabled: true
 #    store_resource_in_lucene_index_enabled: true
-###  This is configuration for normalized quantity serach level default is 0
+###  This is configuration for normalized quantity search level default is 0
 ###   0: NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED - default
 ###   1: NORMALIZED_QUANTITY_STORAGE_SUPPORTED
 ###   2: NORMALIZED_QUANTITY_SEARCH_SUPPORTED

--- a/base/freestanding/femr/config/fhir/application.yaml
+++ b/base/freestanding/femr/config/fhir/application.yaml
@@ -1,3 +1,5 @@
+# https://raw.githubusercontent.com/hapifhir/hapi-fhir-jpaserver-starter/v6.2.2/src/main/resources/application.yaml
+
 #Adds the option to go to eg. http://localhost:8080/actuator/health for seeing the running configuration
 #see https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
 management:

--- a/base/freestanding/femr/config/fhir/application.yaml
+++ b/base/freestanding/femr/config/fhir/application.yaml
@@ -1,84 +1,126 @@
+#Adds the option to go to eg. http://localhost:8080/actuator/health for seeing the running configuration
+#see https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
 spring:
+  main:
+    allow-circular-references: true
+    #allow-bean-definition-overriding: true
+  flyway:
+    enabled: false
+    check-location: false
+    baselineOnMigrate: true
+  datasource:
+    url: 'jdbc:h2:file:./target/database/h2'
+    #url: jdbc:h2:mem:test_mem
+    username: sa
+    password: null
+    driverClassName: org.h2.Driver
+    max-active: 15
+
+    # database connection pool size
+    hikari:
+      maximum-pool-size: 10
   jpa:
     properties:
       hibernate.format_sql: false
       hibernate.show_sql: false
-#      hibernate.hbm2ddl.auto: update
-#      hibernate.jdbc.batch_size: 20
-#      hibernate.cache.use_query_cache: false
-#      hibernate.cache.use_second_level_cache: false
-#      hibernate.cache.use_structured_entries: false
-#      hibernate.cache.use_minimal_puts: false
-###    These settings will enable fulltext search with lucene
-#      hibernate.search.enabled: true
+      #Hibernate dialect is automatically detected except Postgres and H2.
+      #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+      #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+
+      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+  #      hibernate.hbm2ddl.auto: update
+  #      hibernate.jdbc.batch_size: 20
+  #      hibernate.cache.use_query_cache: false
+  #      hibernate.cache.use_second_level_cache: false
+  #      hibernate.cache.use_structured_entries: false
+  #      hibernate.cache.use_minimal_puts: false
+  ###    These settings will enable fulltext search with lucene or elastic
+      hibernate.search.enabled: true
+  ### lucene parameters
 #      hibernate.search.backend.type: lucene
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiLuceneAnalysisConfigurer
+#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
 #      hibernate.search.backend.directory.type: local-filesystem
 #      hibernate.search.backend.directory.root: target/lucenefiles
 #      hibernate.search.backend.lucene_version: lucene_current
-  batch:
-    job:
-      enabled: false
-  main:
-#    TODO 5.6.0 -> Prevent duplicate bean definitions in the Spring batch config in HAPI: see:
-    allow-bean-definition-overriding: true
+  ### elastic parameters ===> see also elasticsearch section below <===
+#      hibernate.search.backend.type: elasticsearch
+#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
 hapi:
   fhir:
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
     fhir_version: R4
-### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
-### to determine the FHIR server address
-#   use_apache_address_strategy: false
-### forces the use of the https:// protocol for the returned server address.
-### alternatively, it may be set using the X-Forwarded-Proto header.
-#   use_apache_address_strategy_https: false
-### enable to set the Server URL
-#    server_address: http://hapi.fhir.org/baseR4
-#    defer_indexing_for_codesystems_of_size: 101
-#    install_transitive_ig_dependencies: true
-#    implementationguides:
-###    example from registry (packages.fhir.org)
-#      swiss:
-#        name: swiss.mednet.fhir
-#        version: 0.8.0
-#      example not from registry
-#      ips_1_0_0:
-#        url: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
-#        name: hl7.fhir.uv.ips
-#        version: 1.0.0
-#    supported_resource_types:
-#      - Patient
-#      - Observation
-#    allow_cascading_deletes: true
-#    allow_contains_searches: true
-#    allow_external_references: true
-#    allow_multiple_delete: true
-#    allow_override_default_search_params: true
-#    auto_create_placeholder_reference_targets: false
-#    cql_enabled: true
-#    default_encoding: JSON
-#    default_pretty_print: true
-#    default_page_size: 20
-#    delete_expunge_enabled: true
-#    enable_repository_validating_interceptor: false
-#    enable_index_missing_fields: false
-#    enable_index_contained_resource: false
-    enforce_referential_integrity_on_delete: false
-#    enforce_referential_integrity_on_write: false
-#    etag_support_enabled: true
-#    expunge_enabled: true
-#    daoconfig_client_id_strategy: null
-#    client_id_strategy: ALPHANUMERIC
-#    fhirpath_interceptor_enabled: false
-#    filter_search_enabled: true
-#    graphql_enabled: true
-#    narrative_enabled: true
-#    mdm_enabled: true
-#    partitioning:
-#      allow_references_across_partitions: false
-#      partitioning_include_in_search_hashes: false
+    ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
+    ### to determine the FHIR server address
+    #   use_apache_address_strategy: false
+    ### forces the use of the https:// protocol for the returned server address.
+    ### alternatively, it may be set using the X-Forwarded-Proto header.
+    #   use_apache_address_strategy_https: false
+    ### enable to set the Server URL
+    #    server_address: http://hapi.fhir.org/baseR4
+    #    defer_indexing_for_codesystems_of_size: 101
+    #    install_transitive_ig_dependencies: true
+    #    implementationguides:
+    ###    example from registry (packages.fhir.org)
+    #      swiss:
+    #        name: swiss.mednet.fhir
+    #        version: 0.8.0
+    #      example not from registry
+    #      ips_1_0_0:
+    #        url: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
+    #        name: hl7.fhir.uv.ips
+    #        version: 1.0.0
+    #    supported_resource_types:
+    #      - Patient
+    #      - Observation
+    ##################################################
+    # Allowed Bundle Types for persistence (defaults are: COLLECTION,DOCUMENT,MESSAGE)
+    ##################################################
+    #    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
+    #    allow_cascading_deletes: true
+    #    allow_contains_searches: true
+    #    allow_external_references: true
+    #    allow_multiple_delete: true
+    #    allow_override_default_search_params: true
+    #    auto_create_placeholder_reference_targets: false
+    #    cql_enabled: true
+    #    default_encoding: JSON
+    #    default_pretty_print: true
+    #    default_page_size: 20
+    #    delete_expunge_enabled: true
+    #    enable_repository_validating_interceptor: true
+    #    enable_index_missing_fields: false
+    #    enable_index_of_type: true
+    #    enable_index_contained_resource: false
+    ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
+    ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
+    advanced_lucene_indexing: false
+    bulk_export_enabled: false
+    bulk_import_enabled: false
+    #    enforce_referential_integrity_on_delete: false
+    # This is an experimental feature, and does not fully support _total and other FHIR features.
+    #    enforce_referential_integrity_on_delete: false
+    #    enforce_referential_integrity_on_write: false
+    #    etag_support_enabled: true
+    #    expunge_enabled: true
+    #    client_id_strategy: ALPHANUMERIC
+    #    fhirpath_interceptor_enabled: false
+    #    filter_search_enabled: true
+    #    graphql_enabled: true
+    #    narrative_enabled: true
+    #    mdm_enabled: true
+    #    local_base_urls:
+    #      - https://hapi.fhir.org/baseR4
+    mdm_enabled: false
+    #    partitioning:
+    #      allow_references_across_partitions: false
+    #      partitioning_include_in_search_hashes: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
@@ -90,34 +132,39 @@ hapi:
     search-coord-max-pool-size: 100
     search-coord-queue-capacity: 200
 
-#    logger:
-#      error_format: 'ERROR - ${requestVerb} ${requestUrl}'
-#      format: >-
-#        Path[${servletPath}] Source[${requestHeader.x-forwarded-for}]
-#        Operation[${operationType} ${operationName} ${idOrResourceName}]
-#        UA[${requestHeader.user-agent}] Params[${requestParameters}]
-#        ResponseEncoding[${responseEncodingNoDefault}]
-#      log_exceptions: true
-#      name: fhirtest.access
-#    max_binary_size: 104857600
-    max_page_size: 1000
-#    retain_cached_searches_mins: 60
-#    reuse_cached_search_results_millis: 60000
+    # Threadpool size for BATCH'ed GETs in a bundle.
+    #    bundle_batch_pool_size: 10
+    #    bundle_batch_pool_max_size: 50
+
+    #    logger:
+    #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'
+    #      format: >-
+    #        Path[${servletPath}] Source[${requestHeader.x-forwarded-for}]
+    #        Operation[${operationType} ${operationName} ${idOrResourceName}]
+    #        UA[${requestHeader.user-agent}] Params[${requestParameters}]
+    #        ResponseEncoding[${responseEncodingNoDefault}]
+    #      log_exceptions: true
+    #      name: fhirtest.access
+    #    max_binary_size: 104857600
+    #    max_page_size: 200
+    #    retain_cached_searches_mins: 60
+    #    reuse_cached_search_results_millis: 60000
     tester:
-        home:
-          name: Local Tester
-          server_address: 'http://localhost:8080/fhir'
-          refuse_to_fetch_third_party_urls: false
-          fhir_version: R4
-        global:
-          name: Global Tester
-          server_address: "http://hapi.fhir.org/baseR4"
-          refuse_to_fetch_third_party_urls: false
-          fhir_version: R4
-#    validation:
-#      requests_enabled: true
-#      responses_enabled: true
-#    binary_storage_enabled: true
+      home:
+        name: Local Tester
+        server_address: 'http://localhost:8080/fhir'
+        refuse_to_fetch_third_party_urls: false
+        fhir_version: R4
+      global:
+        name: Global Tester
+        server_address: "http://hapi.fhir.org/baseR4"
+        refuse_to_fetch_third_party_urls: false
+        fhir_version: R4
+    #    validation:
+    #      requests_enabled: true
+    #      responses_enabled: true
+    #    binary_storage_enabled: true
+    inline_resource_storage_below_size: 4000
 #    bulk_export_enabled: true
 #    subscription:
 #      resthook_enabled: true
@@ -133,6 +180,7 @@ hapi:
 #        startTlsRequired:
 #        quitWait:
 #    lastn_enabled: true
+#    store_resource_in_lucene_index_enabled: true
 ###  This is configuration for normalized quantity serach level default is 0
 ###   0: NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED - default
 ###   1: NORMALIZED_QUANTITY_STORAGE_SUPPORTED

--- a/base/freestanding/femr/config/fhir/application.yaml
+++ b/base/freestanding/femr/config/fhir/application.yaml
@@ -103,8 +103,8 @@ hapi:
     ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
     ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
     advanced_lucene_indexing: false
-    bulk_export_enabled: false
-    bulk_import_enabled: false
+    bulk_export_enabled: true
+    bulk_import_enabled: true
     #    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
     #    enforce_referential_integrity_on_delete: false

--- a/base/freestanding/femr/docker-compose.auth-proxy.yaml
+++ b/base/freestanding/femr/docker-compose.auth-proxy.yaml
@@ -46,12 +46,12 @@ services:
       - traefik.http.routers.auth-proxy-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.auth-proxy-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
-      # oauth2-proxy does not EXPOSE the ports it listens on, requiring explicit traefik configuration
-      - traefik.http.services.auth-proxy-${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=4180
-
       - traefik.http.middlewares.oidc-auth-${COMPOSE_PROJECT_NAME}.forwardAuth.address=http://auth-proxy-${COMPOSE_PROJECT_NAME}:4180/
       - traefik.http.middlewares.oidc-auth-${COMPOSE_PROJECT_NAME}.forwardAuth.trustForwardHeader=true
       - traefik.http.middlewares.oidc-auth-${COMPOSE_PROJECT_NAME}.forwardAuth.authResponseHeaders=X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token,Authorization
+    # oauth2-proxy does not EXPOSE (advertise) the ports it listens on in its docker image
+    expose:
+      - 4180
     networks:
       ingress:
         aliases:

--- a/base/freestanding/femr/docker-compose.auth-proxy.yaml
+++ b/base/freestanding/femr/docker-compose.auth-proxy.yaml
@@ -61,6 +61,9 @@ services:
   fhir:
     labels:
       - traefik.enable=true
+      # Hapi does not EXPOSE the ports it listens on, requiring explicit traefik configuration
+      - traefik.http.services.fhir-auth-${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=8080
+
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir-auth.${BASE_DOMAIN:-localtest.me}`)
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.middlewares=oidc-auth-${COMPOSE_PROJECT_NAME}
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/base/freestanding/femr/docker-compose.auth-proxy.yaml
+++ b/base/freestanding/femr/docker-compose.auth-proxy.yaml
@@ -61,9 +61,6 @@ services:
   fhir:
     labels:
       - traefik.enable=true
-      # Hapi does not EXPOSE the ports it listens on, requiring explicit traefik configuration
-      - traefik.http.services.fhir-auth-${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=8080
-
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir-auth.${BASE_DOMAIN:-localtest.me}`)
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.middlewares=oidc-auth-${COMPOSE_PROJECT_NAME}
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -99,8 +99,6 @@ services:
 
       hapi.fhir.bulk_export_enabled: "true"
       hapi.fhir.bulk_import_enabled: "true"
-      # allow FHIR resources to be written even if resources they refer to are not present on the same server
-      hapi.fhir.enforce_referential_integrity_on_write: "false"
       # TODO remove when cascading delete generally available in FHIR REST API
       hapi.fhir.enforce_referential_integrity_on_delete: "false"
       # allow direct assignment of resource IDs in any format

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -88,14 +88,14 @@ services:
 
 
   fhir:
-    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v5.5.1}
+    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v6.2.2}
     environment:
       SPRING_CONFIG_LOCATION: file:///opt/application.yaml
       spring.datasource.url: jdbc:postgresql://db:5432/hapifhir
       spring.datasource.username: postgres
       spring.datasource.password: postgres
       spring.datasource.driverClassName: org.postgresql.Driver
-      spring.jpa.hibernate.dialect: org.hibernate.dialect.PostgreSQL94Dialect
+      spring.jpa.properties.hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
 
       # make URLs relative to dashboard to allow pagination
       # TODO remove when dashboard is able to rewrite URLs

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -115,6 +115,9 @@ services:
       - "./config/fhir/application.yaml:/opt/application.yaml:ro"
     depends_on:
       - db
+    # Hapi does not EXPOSE (advertise) the ports it listens on in its docker image
+    expose:
+      - 8080
     networks:
       internal:
         aliases:

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
 
 
   fhir:
-    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v6.2.2}
+    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v6.8.3}
     environment:
       SPRING_CONFIG_LOCATION: file:///opt/application.yaml
       spring.datasource.url: jdbc:postgresql://db:5432/hapifhir
@@ -96,6 +96,15 @@ services:
       spring.datasource.password: postgres
       spring.datasource.driverClassName: org.postgresql.Driver
       spring.jpa.properties.hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+
+      hapi.fhir.bulk_export_enabled: "true"
+      hapi.fhir.bulk_import_enabled: "true"
+      # allow FHIR resources to be written even if resources they refer to are not present on the same server
+      hapi.fhir.enforce_referential_integrity_on_write: "false"
+      # TODO remove when cascading delete generally available in FHIR REST API
+      hapi.fhir.enforce_referential_integrity_on_delete: "false"
+      # allow direct assignment of resource IDs in any format
+      hapi.fhir.client_id_strategy: ANY
 
       # make URLs relative to dashboard to allow pagination
       # TODO remove when dashboard is able to rewrite URLs


### PR DESCRIPTION
- Upgrade Hapi to latest version (as of 2023-10) with functional Bulk Export (and Import)

- [ ] NB: Do not upgrade existing 5.5.1 deploys until we have a mechanism to migrate data