### PR TITLE
Add fhir migrations and new SearchParameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.env
 .env
 ehr/cosri/config/pdmp/certs/*
+*__pycache__

--- a/base/freestanding/femr/config/migrations/next_appt_search_parameter.py
+++ b/base/freestanding/femr/config/migrations/next_appt_search_parameter.py
@@ -1,0 +1,48 @@
+import requests
+import json
+import logging
+import os
+
+# Migration script to add SearchParameter for next appointment extension
+revision = '985f4e1e-29f5-4911-bc9c-2c774b685289'
+down_revision = 'None'
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Define the FHIR server base URL
+FHIR_SERVER_URL = os.getenv('FHIR_URL')
+
+# Headers for FHIR requests
+HEADERS = {
+    'Content-Type': 'application/fhir+json'
+}
+SP_ID = "NextAppointmentTimeSearchParameter"
+
+
+def upgrade():
+    # Insert new SearchParameter
+    sp_resource = {
+        "resourceType": "SearchParameter",
+        "id": SP_ID,
+        "name": "NextAppointmentTimeSearchParameter",
+        "status": "active",
+        "description": "Search by patient extension for next appointment",
+        "code": "date-time-of-next-appointment",
+        "base": [ "Patient" ],
+        "type": "date",
+        "expression": "Patient.extension('http://www.uwmedicine.org/time_of_next_appointment').valueDateTime"
+    }
+    response = requests.put(f'{FHIR_SERVER_URL}SearchParameter/{SP_ID}', headers=HEADERS, data=json.dumps(sp_resource))
+    if response.status_code == 200 or response.status_code == 201:
+        logging.info('SearchParameter created successfully.')
+    else:
+        logging.error(f'Failed to create SearchParameter: {response.status_code} {response.text}')
+
+def downgrade():
+    # Reverse upgrade by deleting new SearchParameter
+    response = requests.delete(f'{FHIR_SERVER_URL}SearchParameter/{SP_ID}', headers=HEADERS)
+    if response.status_code == 200 or response.status_code == 204:
+        logging.info('SearchParameter deleted successfully.')
+    else:
+        logging.error(f'Failed to delete SearchParameter: {response.status_code} {response.text}')

--- a/base/freestanding/femr/config/migrations/next_appt_search_parameter.py
+++ b/base/freestanding/femr/config/migrations/next_appt_search_parameter.py
@@ -34,15 +34,10 @@ def upgrade():
         "expression": "Patient.extension('http://www.uwmedicine.org/time_of_next_appointment').valueDateTime"
     }
     response = requests.put(f'{FHIR_SERVER_URL}SearchParameter/{SP_ID}', headers=HEADERS, data=json.dumps(sp_resource))
-    if response.status_code == 200 or response.status_code == 201:
-        logging.info('SearchParameter created successfully.')
-    else:
-        logging.error(f'Failed to create SearchParameter: {response.status_code} {response.text}')
+    response.raise_for_status()
+
 
 def downgrade():
     # Reverse upgrade by deleting new SearchParameter
     response = requests.delete(f'{FHIR_SERVER_URL}SearchParameter/{SP_ID}', headers=HEADERS)
-    if response.status_code == 200 or response.status_code == 204:
-        logging.info('SearchParameter deleted successfully.')
-    else:
-        logging.error(f'Failed to delete SearchParameter: {response.status_code} {response.text}')
+    response.raise_for_status()

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       EXTERNAL_FHIR_API: 'http://pdmp-internal:8008/v/r2/fhir/'
       # FHIR URL queried by PDMP integration backend
       MAP_API: "http://fhir-internal:8080/fhir/"
+      FHIR_URL: "http://fhir-internal:8080/fhir/"
+      MIGRATION_SCRIPTS_DIR: /opt/migrations
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
       SOF_CLIENT_LAUNCH_URL: 'https://backend.${BASE_DOMAIN:-localtest.me}/auth/launch'
@@ -30,6 +32,8 @@ services:
     networks:
       - ingress
       - internal
+    volumes:
+      - ./config/migrations:/opt/migrations
 
 
   keycloak:

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       EXTERNAL_FHIR_API: 'http://pdmp-internal:8008/v/r2/fhir/'
       # FHIR URL queried by PDMP integration backend
       MAP_API: "http://fhir-internal:8080/fhir/"
+      # fhir-migrations run against FHIR_URL
       FHIR_URL: "http://fhir-internal:8080/fhir/"
       MIGRATION_SCRIPTS_DIR: /opt/migrations
       # FHIR URL passed to SoF client


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2493717/stories/188376912 requires a new SearchParameter.

Bringing [fhir-migrations](https://github.com/uwcirg/fhir-migrations) into cosri dashboard for easier maintenance of FHIR resource changes.

Includes first migration script `next_appt_search_parameter.py` to satisfy story need.

TODO: consider extending Dockerfile to run `flask upgrade` on every deploy.
NB: depends on https://github.com/uwcirg/cosri-patientsearch/pull/230