### PR TITLE
SearchParameter must sort by `value` regardless of actual attribute

### DIFF
--- a/base/freestanding/femr/config/migrations/next_appt_search_parameter.py
+++ b/base/freestanding/femr/config/migrations/next_appt_search_parameter.py
@@ -31,7 +31,7 @@ def upgrade():
         "code": "date-time-of-next-appointment",
         "base": [ "Patient" ],
         "type": "date",
-        "expression": "Patient.extension('http://www.uwmedicine.org/time_of_next_appointment').valueDateTime"
+        "expression": "Patient.extension('http://www.uwmedicine.org/time_of_next_appointment').value"
     }
     response = requests.put(f'{FHIR_SERVER_URL}SearchParameter/{SP_ID}', headers=HEADERS, data=json.dumps(sp_resource))
     response.raise_for_status()


### PR DESCRIPTION
SearchParameter must sort by `value` regardless of actual attribute (i.e. `valueDateTime`) being used.