### PR TITLE
Add default SoF client

### DIFF
--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
       SOF_CLIENT_LAUNCH_URL: 'https://backend.${BASE_DOMAIN:-localtest.me}/auth/launch'
+      SOF_CLIENTS: '[{"id":"COSRI", "label":"View", "launch_url":"https://backend.${BASE_DOMAIN}/auth/launch"}]'
       LOGSERVER_URL: "https://logs.${BASE_DOMAIN:-localtest.me}"
       REDIS_URL: redis://redis:6379/1
     depends_on:


### PR DESCRIPTION
Add default SoF client for cosri pain management summary (originally implemented in DCW/ISACC)