### PR TITLE
Feature/timewarp data

### DIFF
--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -177,7 +177,7 @@ services:
 
   timewarp:
     image: ghcr.io/uwcirg/fhir-mock-data:${TIMEWARP_IMAGE_TAG:-latest}
-    # include `--profile manual` in docker-compose calls; hiden by default
+    # include `--profile manual` in docker-compose calls; hidden by default
     profiles:
       - manual
     networks:

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -175,6 +175,11 @@ services:
     networks:
       - internal
 
+  timewarp:
+    image: ghcr.io/uwcirg/fhir-mock-data:${TIMEWARP_IMAGE_TAG:-latest}
+    # include `--profile manual` in docker-compose calls; hiden by default
+    profiles:
+      - manual
 
   redis:
     image: redis

--- a/base/freestanding/femr/docker-compose.yaml
+++ b/base/freestanding/femr/docker-compose.yaml
@@ -180,6 +180,8 @@ services:
     # include `--profile manual` in docker-compose calls; hiden by default
     profiles:
       - manual
+    networks:
+      - internal
 
   redis:
     image: redis

--- a/dev/freestanding/femr/default.env
+++ b/dev/freestanding/femr/default.env
@@ -16,6 +16,7 @@
 # HYDRANT_IMAGE_TAG=tag-from-topic-branch
 # PDMP_IMAGE_TAG=tag-from-topic-branch
 # PROXY_IMAGE_TAG=tag-from-topic-branch
+# TIMEWARP_IMAGE_TAG=tag-from-topic-branch
 
 COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compose.yaml
 
@@ -23,10 +24,11 @@ COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compos
 # COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:../../../base/freestanding/femr/docker-compose.auth-proxy.yaml:./docker-compose.yaml
 
 # docker-compose development overrides; uncomment to enable
-# COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compose.yaml:docker-compose.dev.pdmp.yaml:docker-compose.dev.dashboard.yaml:docker-compose.dev.hydrant.yaml:docker-compose.dev.keycloak.yaml
+# COMPOSE_FILE=../../../base/freestanding/femr/docker-compose.yaml:./docker-compose.yaml:docker-compose.dev.pdmp.yaml:docker-compose.dev.dashboard.yaml:docker-compose.dev.hydrant.yaml:docker-compose.dev.keycloak.yaml:docker-compose.dev.timewarp.yaml
 
 # uncomment & modify if using above development overrides
 # PDMP_CHECKOUT_DIR=
 # DASHBOARD_CHECKOUT_DIR=
 # FHIRWALL_CHECKOUT_DIR=
 # HYDRANT_CHECKOUT_DIR=
+# TIMEWARP_CHECKOUT_DIR=

--- a/dev/freestanding/femr/docker-compose.dev.timewarp.yaml
+++ b/dev/freestanding/femr/docker-compose.dev.timewarp.yaml
@@ -1,0 +1,9 @@
+# docker-compose development override for timewarp service
+version: "3.7"
+services:
+  timewarp:
+    environment:
+      PLACEHOLDER: development
+    volumes:
+    # set in .env
+      - '${TIMEWARP_CHECKOUT_DIR}/:/opt/app'

--- a/dev/freestanding/femr/docker-compose.yaml
+++ b/dev/freestanding/femr/docker-compose.yaml
@@ -48,3 +48,7 @@ services:
   hydrant:
     env_file:
       - ../../../dev/freestanding/femr/hydrant.env
+
+  timewarp:
+    env_file:
+      - ../../../dev/freestanding/femr/timewarp.env


### PR DESCRIPTION
Add the [timewarp-utility](https://github.com/uwcirg/fhir-mock-data/pull/6) to `femr` behind the `manual` --profile so it's only started up and available with the addition of `--profile manual` in the standard docker-compose calls.

i.e. to pull and start from the freestanding/femr directory of a deploy:
```
dc --profile manual pull
dc --profile manual up
```